### PR TITLE
[1.19.2] Use ParticleOptions for custom torches

### DIFF
--- a/common/src/main/java/it/crystalnest/soul_fire_d/api/FireManager.java
+++ b/common/src/main/java/it/crystalnest/soul_fire_d/api/FireManager.java
@@ -16,6 +16,8 @@ import it.crystalnest.soul_fire_d.api.block.entity.DynamicBlockEntityType;
 import it.crystalnest.soul_fire_d.api.type.FireTypeChanger;
 import it.crystalnest.soul_fire_d.api.type.FireTyped;
 import net.minecraft.core.Registry;
+import net.minecraft.core.particles.ParticleOptions;
+import net.minecraft.core.particles.ParticleType;
 import net.minecraft.core.particles.ParticleTypes;
 import net.minecraft.core.particles.SimpleParticleType;
 import net.minecraft.nbt.CompoundTag;
@@ -321,7 +323,7 @@ public final class FireManager {
    * @param <T> particle type.
    * @return supplier for the registered particle type.
    */
-  public static <T extends SimpleParticleType> Supplier<T> registerParticle(ResourceLocation fireType, Supplier<T> supplier) {
+  public static <T extends ParticleType<?>> Supplier<T> registerParticle(ResourceLocation fireType, Supplier<T> supplier) {
     return CobwebRegistry.of(Registry.PARTICLE_TYPE, fireType.getNamespace()).register(FireManager.getComponentPath(fireType, Fire.Component.FLAME_PARTICLE), supplier);
   }
 
@@ -349,8 +351,8 @@ public final class FireManager {
    */
   public static <T extends CustomTorchBlock, W extends CustomWallTorchBlock> Pair<Supplier<T>, Supplier<W>> registerTorch(
     ResourceLocation fireType,
-    BiFunction<ResourceLocation, Supplier<SimpleParticleType>, T> torchSupplier,
-    BiFunction<ResourceLocation, Supplier<SimpleParticleType>, W> wallTorchSupplier
+    BiFunction<ResourceLocation, Supplier<? extends ParticleOptions>, T> torchSupplier,
+    BiFunction<ResourceLocation, Supplier<? extends ParticleOptions>, W> wallTorchSupplier
   ) {
     CobwebRegister<Block> blocks = CobwebRegistry.ofBlocks(fireType.getNamespace());
     return Pair.of(

--- a/common/src/main/java/it/crystalnest/soul_fire_d/api/block/CustomTorchBlock.java
+++ b/common/src/main/java/it/crystalnest/soul_fire_d/api/block/CustomTorchBlock.java
@@ -4,7 +4,7 @@ import it.crystalnest.soul_fire_d.api.Fire;
 import it.crystalnest.soul_fire_d.api.FireManager;
 import it.crystalnest.soul_fire_d.api.type.FireTyped;
 import net.minecraft.core.BlockPos;
-import net.minecraft.core.particles.SimpleParticleType;
+import net.minecraft.core.particles.ParticleOptions;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.util.RandomSource;
 import net.minecraft.world.level.Level;
@@ -28,13 +28,13 @@ public class CustomTorchBlock extends TorchBlock implements FireTyped {
   /**
    * Particle type.
    */
-  private final Supplier<SimpleParticleType> type;
+  private final Supplier<? extends ParticleOptions> type;
 
   /**
    * @param fireType fire type.
    * @param type particle type.
    */
-  public CustomTorchBlock(ResourceLocation fireType, Supplier<SimpleParticleType> type) {
+  public CustomTorchBlock(ResourceLocation fireType, Supplier<? extends ParticleOptions> type) {
     this(fireType, type, Properties.of(Material.DECORATION).noCollission().instabreak().sound(SoundType.WOOD));
   }
 
@@ -43,7 +43,7 @@ public class CustomTorchBlock extends TorchBlock implements FireTyped {
    * @param type particle type.
    * @param properties block properties.
    */
-  public CustomTorchBlock(ResourceLocation fireType, Supplier<SimpleParticleType> type, Properties properties) {
+  public CustomTorchBlock(ResourceLocation fireType, Supplier<? extends ParticleOptions> type, Properties properties) {
     // noinspection DataFlowIssue
     super(properties.lightLevel(state -> FireManager.getProperty(fireType, Fire::getLight)), null);
     this.fireType = fireType;

--- a/common/src/main/java/it/crystalnest/soul_fire_d/api/block/CustomWallTorchBlock.java
+++ b/common/src/main/java/it/crystalnest/soul_fire_d/api/block/CustomWallTorchBlock.java
@@ -4,7 +4,7 @@ import it.crystalnest.soul_fire_d.api.Fire;
 import it.crystalnest.soul_fire_d.api.FireManager;
 import it.crystalnest.soul_fire_d.api.type.FireTyped;
 import net.minecraft.core.BlockPos;
-import net.minecraft.core.particles.SimpleParticleType;
+import net.minecraft.core.particles.ParticleOptions;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.util.RandomSource;
 import net.minecraft.world.level.Level;
@@ -28,13 +28,13 @@ public class CustomWallTorchBlock extends WallTorchBlock implements FireTyped {
   /**
    * Particle type.
    */
-  private final Supplier<SimpleParticleType> type;
+  private final Supplier<? extends ParticleOptions> type;
 
   /**
    * @param fireType fire type.
    * @param type particle type.
    */
-  public CustomWallTorchBlock(ResourceLocation fireType, Supplier<SimpleParticleType> type) {
+  public CustomWallTorchBlock(ResourceLocation fireType, Supplier<? extends ParticleOptions> type) {
     this(fireType, type, Properties.of(Material.DECORATION).noCollission().instabreak().sound(SoundType.WOOD).dropsLike(FireManager.getRequiredComponent(fireType, Fire.Component.TORCH_BLOCK)));
   }
 
@@ -43,7 +43,7 @@ public class CustomWallTorchBlock extends WallTorchBlock implements FireTyped {
    * @param type particle type.
    * @param properties block properties.
    */
-  public CustomWallTorchBlock(ResourceLocation fireType, Supplier<SimpleParticleType> type, Properties properties) {
+  public CustomWallTorchBlock(ResourceLocation fireType, Supplier<? extends ParticleOptions> type, Properties properties) {
     // noinspection DataFlowIssue
     super(properties.lightLevel(state -> FireManager.getProperty(fireType, Fire::getLight)), null);
     this.fireType = fireType;


### PR DESCRIPTION
Hello. As I was reviewing infernalstudios/Infernal-Expansion#462, I noticed a few issues with Soul Fire'd that I would like addressed. Here is the first of two PRs.

## Type of change

Please select the option(s) that are relevant.  
To select an option, change `[ ]` to `[x]`.

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Documentation enhancement (documentation related update)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Description

Previously, Soul Fire'd custom torch blocks would consume type `Supplier<SimpleParticleType>` in order to replace the base attribute `flameParticle`. However, this means that only `SimpleParticleType` particles can be used with custom torches. Any other particle that is not housed in a simple particle type instance would not be accepted at compile-time.

# Changes summary

Most usages of `Supplier<SimpleParticleType>` have been replaced with `Supplier<? extends ParticleOptions>`. The wildcard is to aid in compile-time checking of the supplier so that modders who use this API do not need to unnecessarily cast their supplier. This does not break compatibility, because SimpleParticleType itself is an implementation of ParticleOptions.

# How Has This Been Tested?

Running the game and verifying that nothing breaks. Also, make a ParticleOptions supplier and use it yourself.

# Guidelines:

Please check the element below.  
- [X] I have read and thoroughly followed the [contributing guidelines](https://github.com/Crystal-Nest/.github/blob/main/.github/CONTRIBUTING.md), and my code abides by this project's [code style](https://github.com/Crystal-Nest/.github/blob/main/.github/CONTRIBUTING.md#code-style).
