### PR TITLE
[1.19.2] Use compat-friendly injectors from MixinExtras

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -13,6 +13,8 @@ dependencies {
   compileOnly group: "org.spongepowered", name: "mixin", version: "0.8.5"
   implementation "it.crystalnest:cobweb-common:${minecraft_version}-${cobweb_version}"
   implementation "net.minecraftforge:forgeconfigapiport-fabric:${fcap_version}"
+
+  compileOnly "io.github.llamalad7:mixinextras-common:${mixinextras_version}"
 }
 
 // Disable publishing tasks where common is not published

--- a/common/src/main/java/it/crystalnest/soul_fire_d/api/FireManager.java
+++ b/common/src/main/java/it/crystalnest/soul_fire_d/api/FireManager.java
@@ -756,7 +756,6 @@ public final class FireManager {
    * @param seconds amount of seconds the fire should last for.
    * @param fireType fire type.
    */
-  @Deprecated(forRemoval = true)
   public static void setOnFire(Entity entity, int seconds, ResourceLocation fireType) {
     setOnFire(entity, seconds, fireType, Entity::setSecondsOnFire);
   }
@@ -769,6 +768,7 @@ public final class FireManager {
    * @param fireType fire type.
    * @param setOnFireFunction how to set the entity on fire.
    */
+  @ApiStatus.Internal
   public static void setOnFire(Entity entity, int seconds, ResourceLocation fireType, BiConsumer<Entity, Integer> setOnFireFunction) {
     setOnFireFunction.accept(entity, seconds);
     ((FireTypeChanger) entity).setFireType(ensure(fireType));
@@ -782,7 +782,6 @@ public final class FireManager {
    * @param fireType fire type.
    * @return whether the {@code entity} has been harmed.
    */
-  @Deprecated(forRemoval = true)
   public static boolean damageInFire(Entity entity, ResourceLocation fireType) {
     return damageInFire(entity, fireType, Entity::hurt);
   }
@@ -796,6 +795,7 @@ public final class FireManager {
    * @param hurtFunction how to harm the {@code entity}.
    * @return whether the {@code entity} has been harmed.
    */
+  @ApiStatus.Internal
   public static boolean damageInFire(Entity entity, ResourceLocation fireType, TriFunction<Entity, DamageSource, Float, Boolean> hurtFunction) {
     ((FireTypeChanger) entity).setFireType(ensure(fireType));
     return harmOrHeal(entity, getInFireDamageSource(fireType), FireManager.getProperty(fireType, Fire::getDamage), FireManager.getProperty(fireType, Fire::invertHealAndHarm), hurtFunction);
@@ -809,7 +809,6 @@ public final class FireManager {
    * @param fireType fire type.
    * @return whether the {@code entity} has been harmed.
    */
-  @Deprecated(forRemoval = true)
   public static boolean damageOnFire(Entity entity, ResourceLocation fireType) {
     return damageOnFire(entity, fireType, Entity::hurt);
   }
@@ -823,24 +822,10 @@ public final class FireManager {
    * @param hurtFunction how to harm the {@code entity}.
    * @return whether the {@code entity} has been harmed.
    */
+  @ApiStatus.Internal
   public static boolean damageOnFire(Entity entity, ResourceLocation fireType, TriFunction<Entity, DamageSource, Float, Boolean> hurtFunction) {
     ((FireTypeChanger) entity).setFireType(ensure(fireType));
     return harmOrHeal(entity, getOnFireDamageSource(fireType), FireManager.getProperty(fireType, Fire::getDamage), FireManager.getProperty(fireType, Fire::invertHealAndHarm), hurtFunction);
-  }
-
-  /**
-   * Harms or heals the given {@code entity}.<br />
-   * Also applies the custom fire behavior.
-   *
-   * @param entity entity to harm/heal.
-   * @param damageSource damage source.
-   * @param damage damage/heal amount.
-   * @param invertHealAndHarm whether to invert heal and harm.
-   * @return whether the {@code entity} has been harmed.
-   */
-  @Deprecated(forRemoval = true)
-  private static boolean harmOrHeal(Entity entity, DamageSource damageSource, float damage, boolean invertHealAndHarm) {
-    return harmOrHeal(entity, damageSource, damage, invertHealAndHarm, Entity::hurt);
   }
 
   /**

--- a/common/src/main/java/it/crystalnest/soul_fire_d/api/FireManager.java
+++ b/common/src/main/java/it/crystalnest/soul_fire_d/api/FireManager.java
@@ -1,6 +1,7 @@
 package it.crystalnest.soul_fire_d.api;
 
 import com.google.common.base.Suppliers;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import it.crystalnest.cobweb.api.pack.DynamicDataPack;
 import it.crystalnest.cobweb.api.pack.DynamicTagBuilder;
 import it.crystalnest.cobweb.api.registry.CobwebRegister;
@@ -33,6 +34,7 @@ import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockBehaviour;
 import net.minecraft.world.level.material.MaterialColor;
+import org.apache.commons.lang3.function.TriFunction;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.logging.log4j.util.Strings;
 import org.jetbrains.annotations.ApiStatus;
@@ -44,10 +46,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
+import java.util.function.ToIntFunction;
 
 /**
  * Static manager for registered Fires.
@@ -754,8 +758,21 @@ public final class FireManager {
    * @param seconds amount of seconds the fire should last for.
    * @param fireType fire type.
    */
+  @Deprecated(forRemoval = true)
   public static void setOnFire(Entity entity, int seconds, ResourceLocation fireType) {
-    entity.setSecondsOnFire(seconds);
+    setOnFire(entity, seconds, fireType, Entity::setSecondsOnFire);
+  }
+
+  /**
+   * Set on fire the given entity for the given seconds with the given fire type.
+   *
+   * @param entity {@link Entity} to set on fire.
+   * @param seconds amount of seconds the fire should last for.
+   * @param fireType fire type.
+   * @param setOnFireFunction how to set the entity on fire.
+   */
+  public static void setOnFire(Entity entity, int seconds, ResourceLocation fireType, BiConsumer<Entity, Integer> setOnFireFunction) {
+    setOnFireFunction.accept(entity, seconds);
     ((FireTypeChanger) entity).setFireType(ensure(fireType));
   }
 
@@ -767,9 +784,23 @@ public final class FireManager {
    * @param fireType fire type.
    * @return whether the {@code entity} has been harmed.
    */
+  @Deprecated(forRemoval = true)
   public static boolean damageInFire(Entity entity, ResourceLocation fireType) {
+    return damageInFire(entity, fireType, Entity::hurt);
+  }
+
+  /**
+   * Harms (or heals) the given {@code entity} based on the {@link Fire} registered with the given {@code fireType}.<br />
+   * If no {@link Fire} was registered with the given {@code fireType}, defaults to the default {@code damageSource} and {@code damage} to harm the {@code entity}.
+   *
+   * @param entity {@link Entity} to harm or heal.
+   * @param fireType fire type.
+   * @param hurtFunction how to harm the {@code entity}.
+   * @return whether the {@code entity} has been harmed.
+   */
+  public static boolean damageInFire(Entity entity, ResourceLocation fireType, TriFunction<Entity, DamageSource, Float, Boolean> hurtFunction) {
     ((FireTypeChanger) entity).setFireType(ensure(fireType));
-    return harmOrHeal(entity, getInFireDamageSource(fireType), FireManager.getProperty(fireType, Fire::getDamage), FireManager.getProperty(fireType, Fire::invertHealAndHarm));
+    return harmOrHeal(entity, getInFireDamageSource(fireType), FireManager.getProperty(fireType, Fire::getDamage), FireManager.getProperty(fireType, Fire::invertHealAndHarm), hurtFunction);
   }
 
   /**
@@ -780,9 +811,23 @@ public final class FireManager {
    * @param fireType fire type.
    * @return whether the {@code entity} has been harmed.
    */
+  @Deprecated(forRemoval = true)
   public static boolean damageOnFire(Entity entity, ResourceLocation fireType) {
+    return damageOnFire(entity, fireType, Entity::hurt);
+  }
+
+  /**
+   * Harms (or heals) the given {@code entity} based on the {@link Fire} registered with the given {@code fireType}.<br />
+   * If no {@link Fire} was registered with the given {@code fireType}, defaults to the default {@code damageSource} and {@code damage} to harm the {@code entity}.
+   *
+   * @param entity {@link Entity} to harm or heal.
+   * @param fireType fire type.
+   * @param hurtFunction how to harm the {@code entity}.
+   * @return whether the {@code entity} has been harmed.
+   */
+  public static boolean damageOnFire(Entity entity, ResourceLocation fireType, TriFunction<Entity, DamageSource, Float, Boolean> hurtFunction) {
     ((FireTypeChanger) entity).setFireType(ensure(fireType));
-    return harmOrHeal(entity, getOnFireDamageSource(fireType), FireManager.getProperty(fireType, Fire::getDamage), FireManager.getProperty(fireType, Fire::invertHealAndHarm));
+    return harmOrHeal(entity, getOnFireDamageSource(fireType), FireManager.getProperty(fireType, Fire::getDamage), FireManager.getProperty(fireType, Fire::invertHealAndHarm), hurtFunction);
   }
 
   /**
@@ -795,7 +840,7 @@ public final class FireManager {
    * @param invertHealAndHarm whether to invert heal and harm.
    * @return whether the {@code entity} has been harmed.
    */
-  private static boolean harmOrHeal(Entity entity, DamageSource damageSource, float damage, boolean invertHealAndHarm) {
+  private static boolean harmOrHeal(Entity entity, DamageSource damageSource, float damage, boolean invertHealAndHarm, TriFunction<Entity, DamageSource, Float, Boolean> hurtFunction) {
     Predicate<Entity> behavior = FireManager.getProperty(((FireTyped) entity).getFireType(), Fire::getBehavior);
     if (behavior.test(entity) && Float.compare(damage, 0) != 0) {
       if (damage > 0) {
@@ -804,13 +849,13 @@ public final class FireManager {
             livingEntity.heal(damage);
             return false;
           }
-          return livingEntity.hurt(damageSource, damage);
+          return hurtFunction.apply(livingEntity, damageSource, damage);
         }
-        return entity.hurt(damageSource, damage);
+        return hurtFunction.apply(entity, damageSource, damage);
       }
       if (entity instanceof LivingEntity livingEntity) {
         if (livingEntity.isInvertedHealAndHarm() && invertHealAndHarm) {
-          return livingEntity.hurt(damageSource, -damage);
+          return hurtFunction.apply(livingEntity, damageSource, -damage);
         }
         livingEntity.heal(-damage);
         return false;

--- a/common/src/main/java/it/crystalnest/soul_fire_d/api/FireManager.java
+++ b/common/src/main/java/it/crystalnest/soul_fire_d/api/FireManager.java
@@ -840,6 +840,21 @@ public final class FireManager {
    * @param invertHealAndHarm whether to invert heal and harm.
    * @return whether the {@code entity} has been harmed.
    */
+  @Deprecated(forRemoval = true)
+  private static boolean harmOrHeal(Entity entity, DamageSource damageSource, float damage, boolean invertHealAndHarm) {
+    return harmOrHeal(entity, damageSource, damage, invertHealAndHarm, Entity::hurt);
+  }
+
+  /**
+   * Harms or heals the given {@code entity}.<br />
+   * Also applies the custom fire behavior.
+   *
+   * @param entity entity to harm/heal.
+   * @param damageSource damage source.
+   * @param damage damage/heal amount.
+   * @param invertHealAndHarm whether to invert heal and harm.
+   * @return whether the {@code entity} has been harmed.
+   */
   private static boolean harmOrHeal(Entity entity, DamageSource damageSource, float damage, boolean invertHealAndHarm, TriFunction<Entity, DamageSource, Float, Boolean> hurtFunction) {
     Predicate<Entity> behavior = FireManager.getProperty(((FireTyped) entity).getFireType(), Fire::getBehavior);
     if (behavior.test(entity) && Float.compare(damage, 0) != 0) {

--- a/common/src/main/java/it/crystalnest/soul_fire_d/api/FireManager.java
+++ b/common/src/main/java/it/crystalnest/soul_fire_d/api/FireManager.java
@@ -1,7 +1,6 @@
 package it.crystalnest.soul_fire_d.api;
 
 import com.google.common.base.Suppliers;
-import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import it.crystalnest.cobweb.api.pack.DynamicDataPack;
 import it.crystalnest.cobweb.api.pack.DynamicTagBuilder;
 import it.crystalnest.cobweb.api.registry.CobwebRegister;
@@ -51,7 +50,6 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
-import java.util.function.ToIntFunction;
 
 /**
  * Static manager for registered Fires.

--- a/common/src/main/java/it/crystalnest/soul_fire_d/mixin/AbstractArrowMixin.java
+++ b/common/src/main/java/it/crystalnest/soul_fire_d/mixin/AbstractArrowMixin.java
@@ -1,6 +1,5 @@
 package it.crystalnest.soul_fire_d.mixin;
 
-import com.llamalad7.mixinextras.injector.v2.WrapWithCondition;
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import it.crystalnest.soul_fire_d.api.Fire;
@@ -15,7 +14,6 @@ import net.minecraft.world.entity.projectile.Projectile;
 import net.minecraft.world.phys.EntityHitResult;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Redirect;
 
 /**
  * Injects into {@link AbstractArrow} to alter Fire behavior for consistency.

--- a/common/src/main/java/it/crystalnest/soul_fire_d/mixin/AbstractArrowMixin.java
+++ b/common/src/main/java/it/crystalnest/soul_fire_d/mixin/AbstractArrowMixin.java
@@ -1,5 +1,8 @@
 package it.crystalnest.soul_fire_d.mixin;
 
+import com.llamalad7.mixinextras.injector.v2.WrapWithCondition;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import it.crystalnest.soul_fire_d.api.Fire;
 import it.crystalnest.soul_fire_d.api.FireManager;
 import it.crystalnest.soul_fire_d.api.enchantment.FireEnchantmentHelper;
@@ -25,10 +28,11 @@ public abstract class AbstractArrowMixin implements FireTypeChanger {
    *
    * @param caller {@link Entity} invoking (owning) the redirected method.
    * @param seconds seconds the entity should be set on fire for.
+   * @param original the original call that is being redirected.
    */
-  @Redirect(method = "onHitEntity", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/entity/Entity;setSecondsOnFire(I)V"))
-  private void redirectSetSecondsOnFire(Entity caller, int seconds) {
-    FireManager.setOnFire(caller, FireManager.getComponent(getFireType(), Fire.Component.FLAME_ENCHANTMENT) instanceof FireTypedFlameEnchantment flame ? flame.duration(((Projectile) (Object) this).getOwner(), caller, seconds) : seconds, getFireType());
+  @WrapOperation(method = "onHitEntity", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/entity/Entity;setSecondsOnFire(I)V"))
+  private void redirectSetSecondsOnFire(Entity caller, int seconds, Operation<Void> original) {
+    FireManager.setOnFire(caller, FireManager.getComponent(getFireType(), Fire.Component.FLAME_ENCHANTMENT) instanceof FireTypedFlameEnchantment flame ? flame.duration(((Projectile) (Object) this).getOwner(), caller, seconds) : seconds, getFireType(), original::call);
   }
 
   /**
@@ -38,12 +42,13 @@ public abstract class AbstractArrowMixin implements FireTypeChanger {
    * @param caller {@link AbstractArrow} invoking (owning) the redirected method. It's the same as {@code this}.
    * @param seconds seconds the arrow should be set on fire for.
    * @param entity {@link LivingEntity}, a mob, shooting the arrow.
+   * @param original the original call that is being redirected.
    */
-  @Redirect(method = "setEnchantmentEffectsFromEntity", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/entity/projectile/AbstractArrow;setSecondsOnFire(I)V"))
-  private void redirectSetSecondsOnFire(AbstractArrow caller, int seconds, LivingEntity entity) {
+  @WrapOperation(method = "setEnchantmentEffectsFromEntity", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/entity/projectile/AbstractArrow;setSecondsOnFire(I)V"))
+  private void redirectSetSecondsOnFire(AbstractArrow caller, int seconds, Operation<Void> original, LivingEntity entity) {
     FireEnchantmentHelper.FireEnchantment fireEnchantment = FireEnchantmentHelper.getWhichFlame(entity);
     if (fireEnchantment.isApplied()) {
-      FireManager.setOnFire(caller, seconds, fireEnchantment.getFireType());
+      FireManager.setOnFire(caller, seconds, fireEnchantment.getFireType(), original::call);
     }
   }
 }

--- a/common/src/main/java/it/crystalnest/soul_fire_d/mixin/BaseFireBlockMixin.java
+++ b/common/src/main/java/it/crystalnest/soul_fire_d/mixin/BaseFireBlockMixin.java
@@ -19,9 +19,6 @@ import net.minecraft.world.level.block.state.BlockState;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.Redirect;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 /**
  * Injects into {@link BaseFireBlock} to alter Fire behavior for consistency.

--- a/common/src/main/java/it/crystalnest/soul_fire_d/mixin/BaseFireBlockMixin.java
+++ b/common/src/main/java/it/crystalnest/soul_fire_d/mixin/BaseFireBlockMixin.java
@@ -1,5 +1,8 @@
 package it.crystalnest.soul_fire_d.mixin;
 
+import com.llamalad7.mixinextras.injector.ModifyReturnValue;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import it.crystalnest.soul_fire_d.api.Fire;
 import it.crystalnest.soul_fire_d.api.FireManager;
 import it.crystalnest.soul_fire_d.api.block.CustomFireBlock;
@@ -11,6 +14,7 @@ import net.minecraft.world.entity.Entity;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.BaseFireBlock;
+import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
@@ -41,19 +45,18 @@ public abstract class BaseFireBlockMixin implements FireTypeChanger {
   }
 
   /**
-   * Injects before returning in the method {@link BaseFireBlock#getState(BlockGetter, BlockPos)}.<br />
+   * Conditionally modifies the return value of {@link BaseFireBlock#getState(BlockGetter, BlockPos)}.<br />
    * Returns the most appropriate fire {@link BlockState}.
    *
+   * @param original the original block state.
    * @param level level.
    * @param pos position.
-   * @param cir {@link CallbackInfoReturnable}.
    */
-  @Inject(method = "getState", at = @At(value = "RETURN"), cancellable = true)
-  private static void onGetState(BlockGetter level, BlockPos pos, CallbackInfoReturnable<BlockState> cir) {
-    FireManager.getComponentList(Fire.Component.SOURCE_BLOCK).stream()
+  @ModifyReturnValue(method = "getState", at = @At(value = "RETURN"))
+  private static BlockState onGetState(BlockState original, BlockGetter level, BlockPos pos) {
+    return FireManager.getComponentList(Fire.Component.SOURCE_BLOCK).stream()
       .filter(source -> source instanceof CustomFireBlock customFireBlock && customFireBlock.canSurvive(level.getBlockState(pos.below())))
-      .findFirst()
-      .ifPresent(source -> cir.setReturnValue(source.defaultBlockState()));
+      .findFirst().map(Block::defaultBlockState).orElse(original);
   }
 
   /**
@@ -65,8 +68,8 @@ public abstract class BaseFireBlockMixin implements FireTypeChanger {
    * @param damage original damage (normal fire).
    * @return the result of calling the redirected method.
    */
-  @Redirect(method = "entityInside", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/entity/Entity;hurt(Lnet/minecraft/world/damagesource/DamageSource;F)Z"))
-  private boolean redirectHurt(Entity instance, DamageSource damageSource, float damage) {
-    return FireManager.damageInFire(instance, getFireType());
+  @WrapOperation(method = "entityInside", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/entity/Entity;hurt(Lnet/minecraft/world/damagesource/DamageSource;F)Z"))
+  private boolean redirectHurt(Entity instance, DamageSource damageSource, float damage, Operation<Boolean> original) {
+    return FireManager.damageInFire(instance, getFireType(), original::call);
   }
 }

--- a/common/src/main/java/it/crystalnest/soul_fire_d/mixin/BowItemMixin.java
+++ b/common/src/main/java/it/crystalnest/soul_fire_d/mixin/BowItemMixin.java
@@ -1,5 +1,7 @@
 package it.crystalnest.soul_fire_d.mixin;
 
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import it.crystalnest.soul_fire_d.api.FireManager;
 import it.crystalnest.soul_fire_d.api.enchantment.FireEnchantmentHelper;
 import net.minecraft.world.entity.LivingEntity;
@@ -9,7 +11,6 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Redirect;
 
 /**
  * Injects into {@link BowItem} to alter Fire behavior for consistency.
@@ -17,21 +18,23 @@ import org.spongepowered.asm.mixin.injection.Redirect;
 @Mixin(BowItem.class)
 public abstract class BowItemMixin {
   /**
-   * Redirects the call to {@link AbstractArrow#setSecondsOnFire(int)} inside the method {@link BowItem#releaseUsing(ItemStack, Level, LivingEntity, int)}.<br />
-   * Handles setting the arrow on the correct kind of fire if the bow has a custom fire enchantment.
+   * Redirects the call to {@link AbstractArrow#setSecondsOnFire(int)} inside the method
+   * {@link BowItem#releaseUsing(ItemStack, Level, LivingEntity, int)}.<br /> Handles setting the arrow on the correct
+   * kind of fire if the bow has a custom fire enchantment.
    *
-   * @param instance owner of the redirected method.
-   * @param seconds parameter of the redirected method: number of seconds to set the arrow on fire for.
-   * @param bow bow being released.
-   * @param world world inside which the arrow should be generated.
-   * @param user {@link LivingEntity} holding the {@code bow}.
+   * @param instance          owner of the redirected method.
+   * @param seconds           parameter of the redirected method: number of seconds to set the arrow on fire for.
+   * @param original          the original call that is being redirected.
+   * @param bow               bow being released.
+   * @param world             world inside which the arrow should be generated.
+   * @param user              {@link LivingEntity} holding the {@code bow}.
    * @param remainingUseTicks time left before pulling the {@code bow} to the max.
    */
-  @Redirect(method = "releaseUsing", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/entity/projectile/AbstractArrow;setSecondsOnFire(I)V"))
-  private void redirectSetSecondsOnFire(AbstractArrow instance, int seconds, ItemStack bow, Level world, LivingEntity user, int remainingUseTicks) {
+  @WrapOperation(method = "releaseUsing", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/entity/projectile/AbstractArrow;setSecondsOnFire(I)V"))
+  private void redirectSetSecondsOnFire(AbstractArrow instance, int seconds, Operation<Void> original, ItemStack bow, Level world, LivingEntity user, int remainingUseTicks) {
     FireEnchantmentHelper.FireEnchantment fireEnchantment = FireEnchantmentHelper.getWhichFlame(bow);
     if (fireEnchantment.isApplied()) {
-      FireManager.setOnFire(instance, seconds, fireEnchantment.getFireType());
+      FireManager.setOnFire(instance, seconds, fireEnchantment.getFireType(), original::call);
     }
   }
 }

--- a/common/src/main/java/it/crystalnest/soul_fire_d/mixin/CampfireBlockMixin.java
+++ b/common/src/main/java/it/crystalnest/soul_fire_d/mixin/CampfireBlockMixin.java
@@ -1,5 +1,7 @@
 package it.crystalnest.soul_fire_d.mixin;
 
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import it.crystalnest.soul_fire_d.api.FireManager;
 import it.crystalnest.soul_fire_d.api.type.FireTypeChanger;
 import net.minecraft.core.BlockPos;
@@ -12,7 +14,6 @@ import net.minecraft.world.level.block.state.BlockState;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Redirect;
 
 /**
  * Injects into {@link CampfireBlock} to alter Fire behavior for consistency.
@@ -44,8 +45,8 @@ public abstract class CampfireBlockMixin implements FireTypeChanger {
    * @param damage original damage (normal fire).
    * @return the result of calling the redirected method.
    */
-  @Redirect(method = "entityInside", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/entity/Entity;hurt(Lnet/minecraft/world/damagesource/DamageSource;F)Z"))
-  private boolean redirectHurt(Entity instance, DamageSource damageSource, float damage) {
+  @WrapOperation(method = "entityInside", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/entity/Entity;hurt(Lnet/minecraft/world/damagesource/DamageSource;F)Z"))
+  private boolean redirectHurt(Entity instance, DamageSource damageSource, float damage, Operation<Boolean> original) {
     return FireManager.damageInFire(instance, getFireType());
   }
 }

--- a/common/src/main/java/it/crystalnest/soul_fire_d/mixin/CampfireBlockMixin.java
+++ b/common/src/main/java/it/crystalnest/soul_fire_d/mixin/CampfireBlockMixin.java
@@ -47,6 +47,6 @@ public abstract class CampfireBlockMixin implements FireTypeChanger {
    */
   @WrapOperation(method = "entityInside", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/entity/Entity;hurt(Lnet/minecraft/world/damagesource/DamageSource;F)Z"))
   private boolean redirectHurt(Entity instance, DamageSource damageSource, float damage, Operation<Boolean> original) {
-    return FireManager.damageInFire(instance, getFireType());
+    return FireManager.damageInFire(instance, getFireType(), original::call);
   }
 }

--- a/common/src/main/java/it/crystalnest/soul_fire_d/mixin/EnchantmentHelperMixin.java
+++ b/common/src/main/java/it/crystalnest/soul_fire_d/mixin/EnchantmentHelperMixin.java
@@ -1,5 +1,7 @@
 package it.crystalnest.soul_fire_d.mixin;
 
+import com.llamalad7.mixinextras.injector.wrapmethod.WrapMethod;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import it.crystalnest.soul_fire_d.api.enchantment.FireEnchantmentHelper;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.item.ItemStack;
@@ -7,8 +9,6 @@ import net.minecraft.world.item.enchantment.Enchantment;
 import net.minecraft.world.item.enchantment.EnchantmentHelper;
 import net.minecraft.world.item.enchantment.Enchantments;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 /**
@@ -17,38 +17,44 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 @Mixin(EnchantmentHelper.class)
 public abstract class EnchantmentHelperMixin {
   /**
-   * Injects at the start of the method {@link EnchantmentHelper#getEnchantmentLevel(Enchantment, LivingEntity)}.<br />
-   * Returns the level of any Fire Aspect or Flame.
+   * Injects at the start of the method {@link EnchantmentHelper#getEnchantmentLevel(Enchantment, LivingEntity)}.<br
+   * /> Returns the level of any Fire Aspect or Flame.
    *
    * @param enchantment enchantment to calculate the level of.
-   * @param entity entity with the enchanted equipment.
-   * @param cir {@link CallbackInfoReturnable}.
+   * @param entity      entity with the enchanted equipment.
+   * @param cir         {@link CallbackInfoReturnable}.
+   * @return
    */
-  @Inject(method = "getEnchantmentLevel(Lnet/minecraft/world/item/enchantment/Enchantment;Lnet/minecraft/world/entity/LivingEntity;)I", at = @At(value = "HEAD"), cancellable = true)
-  private static void onGetEnchantmentLevel(Enchantment enchantment, LivingEntity entity, CallbackInfoReturnable<Integer> cir) {
+  @WrapMethod(method = "getEnchantmentLevel(Lnet/minecraft/world/item/enchantment/Enchantment;Lnet/minecraft/world/entity/LivingEntity;)I")
+  private static int onGetEnchantmentLevel(Enchantment enchantment, LivingEntity entity, Operation<Integer> original) {
     if (enchantment == Enchantments.FIRE_ASPECT) {
-      cir.setReturnValue(FireEnchantmentHelper.getAnyFireAspect(entity));
+      return FireEnchantmentHelper.getAnyFireAspect(entity);
     }
     if (enchantment == Enchantments.FLAMING_ARROWS) {
-      cir.setReturnValue(FireEnchantmentHelper.getAnyFlame(entity));
+      return FireEnchantmentHelper.getAnyFlame(entity);
     }
+
+    return original.call(enchantment, entity);
   }
 
   /**
-   * Injects at the start of the method {@link EnchantmentHelper#getItemEnchantmentLevel(Enchantment, ItemStack)}.<br />
-   * Returns the level of any Fire Aspect or Flame.
+   * Injects at the start of the method {@link EnchantmentHelper#getItemEnchantmentLevel(Enchantment, ItemStack)}.<br
+   * /> Returns the level of any Fire Aspect or Flame.
    *
    * @param enchantment enchantment to calculate the level of.
-   * @param stack enchanted {@link ItemStack}.
-   * @param cir {@link CallbackInfoReturnable}.
+   * @param stack       enchanted {@link ItemStack}.
+   * @param cir         {@link CallbackInfoReturnable}.
+   * @return
    */
-  @Inject(method = "getItemEnchantmentLevel", at = @At(value = "HEAD"), cancellable = true)
-  private static void onGetItemEnchantmentLevel(Enchantment enchantment, ItemStack stack, CallbackInfoReturnable<Integer> cir) {
+  @WrapMethod(method = "getItemEnchantmentLevel")
+  private static int onGetItemEnchantmentLevel(Enchantment enchantment, ItemStack stack, Operation<Integer> original) {
     if (enchantment == Enchantments.FIRE_ASPECT) {
-      cir.setReturnValue(FireEnchantmentHelper.getAnyFireAspect(stack));
+      return FireEnchantmentHelper.getAnyFireAspect(stack);
     }
     if (enchantment == Enchantments.FLAMING_ARROWS) {
-      cir.setReturnValue(FireEnchantmentHelper.getAnyFlame(stack));
+      return FireEnchantmentHelper.getAnyFlame(stack);
     }
+
+    return original.call(enchantment, stack);
   }
 }

--- a/common/src/main/java/it/crystalnest/soul_fire_d/mixin/EntityMixin.java
+++ b/common/src/main/java/it/crystalnest/soul_fire_d/mixin/EntityMixin.java
@@ -1,6 +1,5 @@
 package it.crystalnest.soul_fire_d.mixin;
 
-import com.llamalad7.mixinextras.injector.v2.WrapWithCondition;
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import it.crystalnest.soul_fire_d.api.FireManager;
@@ -20,7 +19,6 @@ import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 

--- a/common/src/main/java/it/crystalnest/soul_fire_d/mixin/EntityMixin.java
+++ b/common/src/main/java/it/crystalnest/soul_fire_d/mixin/EntityMixin.java
@@ -1,5 +1,8 @@
 package it.crystalnest.soul_fire_d.mixin;
 
+import com.llamalad7.mixinextras.injector.v2.WrapWithCondition;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import it.crystalnest.soul_fire_d.api.FireManager;
 import it.crystalnest.soul_fire_d.api.type.FireTypeChanger;
 import it.crystalnest.soul_fire_d.api.type.FireTyped;
@@ -82,9 +85,9 @@ public abstract class EntityMixin implements FireTypeChanger {
    * @param damage original damage (normal fire).
    * @return the result of calling the redirected method.
    */
-  @Redirect(method = "baseTick", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/entity/Entity;hurt(Lnet/minecraft/world/damagesource/DamageSource;F)Z"))
-  private boolean redirectHurt(Entity instance, DamageSource damageSource, float damage) {
-    return FireManager.damageOnFire(instance, ((FireTyped) instance).getFireType());
+  @WrapOperation(method = "baseTick", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/entity/Entity;hurt(Lnet/minecraft/world/damagesource/DamageSource;F)Z"))
+  private boolean redirectHurt(Entity instance, DamageSource damageSource, float damage, Operation<Boolean> original) {
+    return FireManager.damageOnFire(instance, ((FireTyped) instance).getFireType(), original::call);
   }
 
   /**
@@ -93,10 +96,11 @@ public abstract class EntityMixin implements FireTypeChanger {
    *
    * @param instance owner of the redirected method.
    * @param seconds seconds to set the entity on fire for.
+   * @param original the original call that is being redirected.
    */
-  @Redirect(method = "lavaHurt", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/entity/Entity;setSecondsOnFire(I)V"))
-  private void redirectSetSecondsOnFire(Entity instance, int seconds) {
-    FireManager.setOnFire(instance, seconds, FireManager.DEFAULT_FIRE_TYPE);
+  @WrapOperation(method = "lavaHurt", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/entity/Entity;setSecondsOnFire(I)V"))
+  private void redirectSetSecondsOnFire(Entity instance, int seconds, Operation<Void> original) {
+    FireManager.setOnFire(instance, seconds, FireManager.DEFAULT_FIRE_TYPE, original::call);
   }
 
   /**

--- a/common/src/main/java/it/crystalnest/soul_fire_d/mixin/ZombieMixin.java
+++ b/common/src/main/java/it/crystalnest/soul_fire_d/mixin/ZombieMixin.java
@@ -8,7 +8,6 @@ import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.monster.Zombie;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Redirect;
 
 /**
  * Injects into {@link Zombie} to alter Fire behavior for consistency.

--- a/common/src/main/java/it/crystalnest/soul_fire_d/mixin/ZombieMixin.java
+++ b/common/src/main/java/it/crystalnest/soul_fire_d/mixin/ZombieMixin.java
@@ -1,5 +1,7 @@
 package it.crystalnest.soul_fire_d.mixin;
 
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import it.crystalnest.soul_fire_d.api.FireManager;
 import it.crystalnest.soul_fire_d.api.type.FireTyped;
 import net.minecraft.world.entity.Entity;
@@ -20,8 +22,8 @@ public abstract class ZombieMixin implements FireTyped {
    * @param instance owner of the redirected method.
    * @param seconds amount of seconds the entity should be set on fire for.
    */
-  @Redirect(method = "doHurtTarget", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/entity/Entity;setSecondsOnFire(I)V"))
-  private void onDoHurtTarget(Entity instance, int seconds) {
-    FireManager.setOnFire(instance, seconds, getFireType());
+  @WrapOperation(method = "doHurtTarget", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/entity/Entity;setSecondsOnFire(I)V"))
+  private void onDoHurtTarget(Entity instance, int seconds, Operation<Void> original) {
+    FireManager.setOnFire(instance, seconds, getFireType(), original::call);
   }
 }

--- a/common/src/main/java/it/crystalnest/soul_fire_d/mixin/client/EntityRenderDispatcherMixin.java
+++ b/common/src/main/java/it/crystalnest/soul_fire_d/mixin/client/EntityRenderDispatcherMixin.java
@@ -1,5 +1,7 @@
 package it.crystalnest.soul_fire_d.mixin.client;
 
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import com.mojang.blaze3d.vertex.PoseStack;
 import it.crystalnest.soul_fire_d.api.FireManager;
 import it.crystalnest.soul_fire_d.api.client.FireClientManager;
@@ -12,7 +14,6 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.Entity;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.ModifyVariable;
 
 /**
  * Injects into {@link EntityRenderDispatcher} to alter Fire behavior for consistency.
@@ -23,38 +24,39 @@ public abstract class EntityRenderDispatcherMixin {
    * Modifies the assignment value returned by the first call to {@link Material#sprite()} in the method {@link EntityRenderDispatcher#renderFlame(PoseStack, MultiBufferSource, Entity)}.<br />
    * Assigns the correct sprite for the fire type the entity is burning from.
    *
-   * @param value original sprite returned by the modified method.
+   * @param originalMaterial material of the original sprite returned by the modified method.
+   * @param original the operation that gets the original sprite returned by the modified method.
    * @param poseStack matrices.
    * @param multiBufferSource buffer.
    * @param entity {@link Entity} that's burning.
    * @return {@link TextureAtlasSprite} to assign.
    */
-  @SuppressWarnings("InvalidInjectorMethodSignature")
-  @ModifyVariable(method = "renderFlame", at = @At(value = "INVOKE_ASSIGN", target = "Lnet/minecraft/client/resources/model/Material;sprite()Lnet/minecraft/client/renderer/texture/TextureAtlasSprite;", ordinal = 0), ordinal = 0)
-  private TextureAtlasSprite onRenderFlameAtSprite0(TextureAtlasSprite value, PoseStack poseStack, MultiBufferSource multiBufferSource, Entity entity) {
+  @WrapOperation(method = "renderFlame", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/resources/model/Material;sprite()Lnet/minecraft/client/renderer/texture/TextureAtlasSprite;", ordinal = 0))
+  private TextureAtlasSprite onRenderFlameAtSprite0(Material originalMaterial, Operation<TextureAtlasSprite> original, PoseStack poseStack, MultiBufferSource multiBufferSource, Entity entity) {
     ResourceLocation fireType = ((FireTyped) entity).getFireType();
     if (FireManager.isRegisteredType(fireType)) {
       return FireClientManager.getSprite0(fireType);
     }
-    return value;
+    return original.call(originalMaterial);
   }
 
   /**
    * Modifies the assignment value returned by the second call to {@link Material#sprite()} in the method {@link EntityRenderDispatcher#renderFlame(PoseStack, MultiBufferSource, Entity)}.<br />
    * Assigns the correct sprite for the fire type the entity is burning from.
    *
-   * @param value original sprite returned by the modified method.
+   * @param originalMaterial material of the original sprite returned by the modified method.
+   * @param original the operation that gets the original sprite returned by the modified method.
    * @param poseStack matrices.
    * @param multiBufferSource buffer.
    * @param entity {@link Entity} that's burning.
    * @return {@link TextureAtlasSprite} to assign.
    */
-  @ModifyVariable(method = "renderFlame", at = @At(value = "INVOKE_ASSIGN", target = "Lnet/minecraft/client/resources/model/Material;sprite()Lnet/minecraft/client/renderer/texture/TextureAtlasSprite;", ordinal = 1), ordinal = 1)
-  private TextureAtlasSprite onRenderFlameAtSprite1(TextureAtlasSprite value, PoseStack poseStack, MultiBufferSource multiBufferSource, Entity entity) {
+  @WrapOperation(method = "renderFlame", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/resources/model/Material;sprite()Lnet/minecraft/client/renderer/texture/TextureAtlasSprite;", ordinal = 1))
+  private TextureAtlasSprite onRenderFlameAtSprite1(Material originalMaterial, Operation<TextureAtlasSprite> original, PoseStack poseStack, MultiBufferSource multiBufferSource, Entity entity) {
     ResourceLocation fireType = ((FireTyped) entity).getFireType();
     if (FireManager.isRegisteredType(fireType)) {
       return FireClientManager.getSprite1(fireType);
     }
-    return value;
+    return original.call(originalMaterial);
   }
 }

--- a/common/src/main/java/it/crystalnest/soul_fire_d/mixin/client/ScreenEffectRendererMixin.java
+++ b/common/src/main/java/it/crystalnest/soul_fire_d/mixin/client/ScreenEffectRendererMixin.java
@@ -1,5 +1,7 @@
 package it.crystalnest.soul_fire_d.mixin.client;
 
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import com.mojang.blaze3d.vertex.PoseStack;
 import it.crystalnest.soul_fire_d.api.FireManager;
 import it.crystalnest.soul_fire_d.api.client.FireClientManager;
@@ -11,7 +13,6 @@ import net.minecraft.client.resources.model.Material;
 import net.minecraft.resources.ResourceLocation;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.ModifyVariable;
 
 /**
  * Injects into {@link ScreenEffectRenderer} to alter Fire behavior for consistency.
@@ -22,18 +23,18 @@ public abstract class ScreenEffectRendererMixin {
    * Modifies the assignment value returned by {@link Material#sprite()} in the method {@link ScreenEffectRenderer#renderFire(Minecraft, PoseStack)}.<br />
    * Assigns the correct sprite for the Fire Type the player is burning from.
    *
-   * @param value original sprite returned by the modified method.
+   * @param originalMaterial material of the original sprite returned by the modified method.
+   * @param original the operation that gets the original sprite returned by the modified method.
    * @param minecraft Minecraft client.
    * @param poseStack matrices.
    * @return {@link TextureAtlasSprite} to assign.
    */
-  @SuppressWarnings("InvalidInjectorMethodSignature")
-  @ModifyVariable(method = "renderFire", at = @At(value = "INVOKE_ASSIGN", target = "Lnet/minecraft/client/resources/model/Material;sprite()Lnet/minecraft/client/renderer/texture/TextureAtlasSprite;"))
-  private static TextureAtlasSprite onRenderFire(TextureAtlasSprite value, Minecraft minecraft, PoseStack poseStack) {
+  @WrapOperation(method = "renderFire", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/resources/model/Material;sprite()Lnet/minecraft/client/renderer/texture/TextureAtlasSprite;"))
+  private static TextureAtlasSprite onRenderFire(Material originalMaterial, Operation<TextureAtlasSprite> original, Minecraft minecraft, PoseStack poseStack) {
     ResourceLocation fireType = minecraft.player != null ? ((FireTyped) minecraft.player).getFireType() : null;
     if (FireManager.isRegisteredType(fireType)) {
       return FireClientManager.getSprite1(fireType);
     }
-    return value;
+    return original.call(originalMaterial);
   }
 }

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -6,6 +6,7 @@ dependencies {
   modImplementation "net.fabricmc:fabric-loader:${fabric_loader_version}"
   modImplementation "net.fabricmc.fabric-api:fabric-api:${fabric_version}"
   compileOnly project(":common")
+  include implementation(annotationProcessor("io.github.llamalad7:mixinextras-fabric:${mixinextras_version}"))
   modImplementation "it.crystalnest:cobweb-fabric:${minecraft_version}-${cobweb_version}"
   modImplementation "net.minecraftforge:forgeconfigapiport-fabric:${fcap_version}"
 }

--- a/forge/build.gradle
+++ b/forge/build.gradle
@@ -1,3 +1,5 @@
+import net.minecraftforge.gradle.userdev.tasks.JarJar
+
 plugins {
   id "net.minecraftforge.gradle" version "[6.0,6.2)"
   id "org.spongepowered.mixin" version "0.7-SNAPSHOT"
@@ -96,6 +98,11 @@ processResources {
 
 jar.finalizedBy("configureReobfTaskForReobfJar")
 jar.finalizedBy("reobfJar")
+jar.archiveClassifier = "no-embeds"
+
+tasks.named('jarJar', JarJar).configure {
+  archiveClassifier = ""
+}
 
 // Task seems bugged, breaks build because of mod dependencies in the Common project, with no apparent workaround.
 tasks.named("compileTestJava").get().setEnabled(false)

--- a/forge/build.gradle
+++ b/forge/build.gradle
@@ -69,7 +69,14 @@ sourceSets.main.resources.srcDir "src/generated/resources"
 dependencies {
   minecraft "net.minecraftforge:forge:${minecraft_version}-${forge_version}"
   compileOnly project(":common")
+
   annotationProcessor("org.spongepowered:mixin:0.8.5-SNAPSHOT:processor")
+  compileOnly annotationProcessor("io.github.llamalad7:mixinextras-common:${mixinextras_version}")
+  implementation(jarJar("io.github.llamalad7:mixinextras-forge:${mixinextras_version}")) {
+    jarJar.pin(it, mixinextras_version)
+    jarJar.ranged(it, "[${mixinextras_version},)")
+  }
+
   implementation fg.deobf("it.crystalnest:cobweb-forge:${minecraft_version}-${cobweb_version}")
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -24,6 +24,7 @@ forge_version = 43.3.0
 forge_loader_version_range = [43,)
 
 # Dependencies
+mixinextras_version = 0.4.1
 cobweb_version = 1.0.0
 fcap_version = 4.2.11
 


### PR DESCRIPTION
Hello again. This is my second PR to accompany my review of infernalstudios/Infernal-Expansion#462. This one is a lot larger, and addresses my main overall concern with Soul Fire'd: the incompatibilities from using `@Redirect` injectors.

## Type of change

Please select the option(s) that are relevant.  
To select an option, change `[ ]` to `[x]`.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation enhancement (documentation related update)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Description

When I went to work on #61, I noticed that open issue #6 involves a crash with a mod that I use in another project that I work on, so I wanted to work on how I could work around this redirect injector issue.

To be frank, the mixins in this mod were in a desperate need of a cleanup. The usage of `@Redirect` is heavily discouraged because of issues like those caused with Aileron, and this mod was using 8 of them. These redirects would then move the method call to somewhere in `FireManager`, where inevitably the redirected method call would just happen at some point (i.e. `entity.hurt()`, `entity.setSecondsOnFire()`). These injectors are a prime candidate for [`@WrapOperation`](https://github.com/LlamaLad7/MixinExtras/wiki/WrapOperation), which wraps the original method call as a function object to be used on your own terms.

# Changes summary

- MixinExtras is now included with Soul Fire'd.
  - This does increase the file size which is a regression of dc21540, but considering the mod compatibility preservation in this PR, I think it is worth it.
  - ForgeGradle will make two main jars: one with no classifier and one with `no-embeds`. The jar with no classifier will contain MixinExtras.
  - I looked into Fabric Loom and couldn't find any way to make a separete jar for included dependencies, since it is part of the `remapJar` task.
  - The common jar is unaffected.
- All usages of `@Inject` at `HEAD` have been replaced with [`@WrapMethod`](https://github.com/LlamaLad7/MixinExtras/wiki/WrapMethod).
  - This is a performance boost since if the method does not need to be called, it never will be. It also does not need to use an instance of `CallbackInfoReturnable<?>`.
- All usages of `@Inject` at `RETURN` in order to change the return value have been replaced with [`@ModifyReturnValue`](https://github.com/LlamaLad7/MixinExtras/wiki/ModifyReturnValue).
  - This allows other mods that also use `@ModifyReturnValue` to chain their changes onto yours, preserving mod compatibility.
- All usages of `@Redirect` have been replaced with `@WrapOperation`.
  - The operation in question would then be passed into `FireManager` where it can be used if needed. This not only fixes the problem of redundantly calling the original method manually, but it also aids in mod compatibility since other mods that target this instruction will have their changes applied.
  - As a side effect, all other mods that use redirect injectors in the same places will no longer cause the game to crash with a "failed to inject required amount" error, as the wrapped operation will include the redirected method call. This means that Aileron's mechanic of giving the player i-frames from campfire damage is preserved.
- Fixes #6.

# How Has This Been Tested?

Run this mod, either in the dev environment or in production, with Aileron. The game will not crash.

As further proof, I'd like to show you what the decompiled class code of `CampfireBlockMixin` looks like with the new `@WrapOperation` mixin that caused the crash in #6:

```java
public void entityInside(BlockState p_51269_, Level p_51270_, BlockPos p_51271_, Entity p_51272_) {
    if ((Boolean)p_51269_.getValue(LIT) && p_51272_ instanceof LivingEntity && !EnchantmentHelper.hasFrostWalker((LivingEntity)p_51272_)) {
        float injectorAllocatedLocal7 = (float)this.fireDamage;
        DamageSource injectorAllocatedLocal6 = DamageSource.IN_FIRE;
        this.wrapOperation$zzd001$redirectHurt(p_51272_, injectorAllocatedLocal6, injectorAllocatedLocal7, (var1) -> {
            WrapOperationRuntime.checkArgumentCount(var1, 3, "[net.minecraft.world.entity.Entity, net.minecraft.world.damagesource.DamageSource, float]");
            return this.redirect$zzm000$hurt((Entity)var1[0], (DamageSource)var1[1], (Float)var1[2]);
        });
    }

    super.entityInside(p_51269_, p_51270_, p_51271_, p_51272_);
}
```

Above is the dumped class of `CampfireBlock` after mixins have been applied. You can see that the wrapped operation injector takes precedence and uses the redirected method call as the operation. Therefore, there is no clash between redirects as the wrapped operation simply consumed the redirect.

While yes, Aileron does need a Mixin cleanup as well, cleaning up Mixins in Soul Fire'd will not only workaround this issue but can prevent other issues that can cause serious headaches when considering mod compatibility.

# Guidelines:

Please check the element below.  
- [X] I have read and thoroughly followed the [contributing guidelines](https://github.com/Crystal-Nest/.github/blob/main/.github/CONTRIBUTING.md), and my code abides by this project's [code style](https://github.com/Crystal-Nest/.github/blob/main/.github/CONTRIBUTING.md#code-style).
